### PR TITLE
Update telegram-bot-daemon.sh

### DIFF
--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -42,15 +42,17 @@ imageAlerts() {
 }
 
 respond() {
-  case $1 in
-    /mem*) sendMem;;
-    /shot*) sendShot;;
-    /on*) detectionOn;;
-    /off*) detectionOff;;
-    /textalerts*) textAlerts;;
-    /imagealerts*) imageAlerts;;
-    /help*) $TELEGRAM m "######### Bot commands #########\n# /mem - show memory information\n# /shot - take a shot\n# /on - motion detect on\n# /off - motion detect off\n# /textalerts - Text alerts on motion detection\n# /imagealerts - Image alerts on motion detection";;
-    *) $TELEGRAM m "I can't respond to '$1' command"
+  cmd=$1
+  [ $chatId -lt 0 ] && cmd=${1%%@*}
+  case $cmd in
+    /mem) sendMem;;
+    /shot) sendShot;;
+    /on) detectionOn;;
+    /off) detectionOff;;
+    /textalerts) textAlerts;;
+    /imagealerts) imageAlerts;;
+    /help | /start) $TELEGRAM m "######### Bot commands #########\n# /mem - show memory information\n# /shot - take a shot\n# /on - motion detect on\n# /off - motion detect off\n# /textalerts - Text alerts on motion detection\n# /imagealerts - Image alerts on motion detection";;
+    *) $TELEGRAM m "I can't respond to '$cmd' command"
   esac
 }
 


### PR DESCRIPTION
Correctly handle situations where commands coming from group chats appear to be substrings of another command (for example /mem will not be matched, if command sent was /members).